### PR TITLE
fix: handle null repositoryOwner and dict-shaped commit author

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Find out more in the [GitHub API documentation](https://docs.github.com/en/rest/
    - `END_DATE`
 
    If no **start and end date** are supplied, the action will consider the entire repository history and be unable to determine if contributors are new or returning.
-   If running on a whole **organization** then no repository is needed.  
+   If running on a whole **organization** then no repository is needed.
    If running the action on just **one repository** or a **list of repositories**, then no organization is needed.
 
-1. Also edit the value for `GH_ENTERPRISE_URL` if you are using a GitHub Server and not using github.com.  
+1. Also edit the value for `GH_ENTERPRISE_URL` if you are using a GitHub Server and not using github.com.
    For github.com users, leave it empty.
 1. If you are running this action on an organization or repository other than the one where the workflow file is going to be, then update the value of `GH_TOKEN`.
    - Do this by creating a [GitHub API token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with permissions to read the repository/organization and write issues.
@@ -223,6 +223,17 @@ jobs:
           content-filepath: ./${{ env.OUTPUT_FILENAME }}
           assignees: <YOUR_GITHUB_HANDLE_HERE>
 ```
+
+#### Posting the report as a GitHub Discussion
+
+A common pattern is piping the generated `contributors.md` into [`abirismyname/create-discussion`](https://github.com/abirismyname/create-discussion) to publish a "thank you" discussion. Two things to know:
+
+1. The job needs `discussions: write` in its `permissions:` block.
+2. **`GITHUB_TOKEN` only works when the discussion is created in the same repository the workflow runs in.** If `repository-id` points at a different repository, the GraphQL call returns `Resource not accessible by integration` regardless of the declared permissions. To post a discussion in another repository, use one of:
+   - A Personal Access Token (classic) with `repo` and `write:discussion` scopes, or a fine-grained PAT with `Discussions: read & write` on the target repo, stored as a repository secret (e.g. `DISCUSSION_TOKEN`).
+   - A GitHub App installed on the target repository, exchanging credentials with [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) and granting the app `Discussions: read & write`.
+
+   Then pass that token as `GH_TOKEN` to the `create-discussion` step instead of `secrets.GITHUB_TOKEN`.
 
 ## Example Markdown output with `start_date` and `end_date` supplied
 

--- a/contributor_stats.py
+++ b/contributor_stats.py
@@ -166,11 +166,15 @@ def get_sponsor_information(contributors: list, token: str, ghe: str) -> list:
         if response.status_code != 200 or "errors" in response.json():
             raise ValueError("GraphQL query failed")
 
-        data = response.json()["data"]
+        data = response.json().get("data") or {}
+        owner = data.get("repositoryOwner")
+        # repositoryOwner is null for Organizations, deleted/renamed users,
+        # and other non-User logins because of the `... on User` fragment.
+        if not owner:
+            continue
 
         endpoint = ghe if ghe else "https://github.com"
-        # if the user has a sponsor page, add it to the contributor object
-        if data["repositoryOwner"]["hasSponsorsListing"]:
+        if owner.get("hasSponsorsListing"):
             contributor.sponsor_info = f"{endpoint}/sponsors/{contributor.username}"
 
     return contributors

--- a/contributors.py
+++ b/contributors.py
@@ -163,39 +163,39 @@ def get_contributors(repo: object, start_date: str, end_date: str, ghe: str):
             # This is much more efficient than iterating all-time contributors
             # and checking each one for commits, which causes rate limiting
             # on large repositories.
-            contributor_data = {}
+            avatars: dict[str, str] = {}
+            counts: dict[str, int] = {}
             for commit in repo.commits(since=start_date, until=end_date):
-                if commit.author is None:
+                # github3.py leaves commit.author as a raw dict (not a ShortUser)
+                # when the API returns an author payload without a matching GitHub user.
+                login = getattr(commit.author, "login", None)
+                if not login or "[bot]" in login:
                     continue
-                login = commit.author.login
-                if "[bot]" in login:
-                    continue
-                if login not in contributor_data:
-                    contributor_data[login] = {
-                        "avatar_url": commit.author.avatar_url,
-                        "contribution_count": 0,
-                    }
-                contributor_data[login]["contribution_count"] += 1
+                if login not in counts:
+                    avatars[login] = getattr(commit.author, "avatar_url", "") or ""
+                    counts[login] = 0
+                counts[login] += 1
 
-            for username, data in contributor_data.items():
+            for username, count in counts.items():
                 commit_url = f"{endpoint}/{repo.full_name}/commits?author={username}&since={start_date}&until={end_date}"
                 contributor = contributor_stats.ContributorStats(
                     username,
-                    data["avatar_url"],
-                    data["contribution_count"],
+                    avatars[username],
+                    count,
                     commit_url,
                     "",
                 )
                 contributors.append(contributor)
         else:
             for user in repo.contributors():
-                if "[bot]" in user.login:
+                login = getattr(user, "login", None)
+                if not login or "[bot]" in login:
                     continue
-                commit_url = f"{endpoint}/{repo.full_name}/commits?author={user.login}"
+                commit_url = f"{endpoint}/{repo.full_name}/commits?author={login}"
                 contributor = contributor_stats.ContributorStats(
-                    user.login,
-                    user.avatar_url,
-                    user.contributions_count,
+                    login,
+                    getattr(user, "avatar_url", "") or "",
+                    getattr(user, "contributions_count", 0) or 0,
                     commit_url,
                     "",
                 )

--- a/test_contributor_stats.py
+++ b/test_contributor_stats.py
@@ -230,6 +230,28 @@ class TestContributorStats(unittest.TestCase):
         )
 
     @patch("requests.post")
+    def test_fetch_sponsor_info_skips_when_repository_owner_is_none(self, mock_post):
+        """Skip users whose repositoryOwner is null (orgs, deleted users, bots)."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": {"repositoryOwner": None}}
+        mock_post.return_value = mock_response
+
+        contributors = [
+            ContributorStats(
+                username="some-org",
+                avatar_url="https://avatars.githubusercontent.com/u/",
+                contribution_count=10,
+                commit_url="url",
+                sponsor_info="",
+            ),
+        ]
+
+        result = get_sponsor_information(contributors, token="token", ghe="")
+
+        self.assertEqual(result[0].sponsor_info, "")
+
+    @patch("requests.post")
     def test_fetch_sponsor_info_raises_on_error(self, mock_post):
         """Test get_sponsor_information raises when the API response is invalid."""
         mock_response = MagicMock()

--- a/test_contributors.py
+++ b/test_contributors.py
@@ -256,10 +256,12 @@ class TestContributors(unittest.TestCase):
         good_user.contributions_count = 5
         mock_repo.contributors.return_value = [bad_user, good_user]
 
-        result = contributors_module.get_contributors(mock_repo, "", "", "")
+        with patch("builtins.print") as mock_print:
+            result = contributors_module.get_contributors(mock_repo, "", "", "")
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].username, "real")
+        mock_print.assert_not_called()
 
     def test_get_contributors_aggregates_multiple_commits(self):
         """Test get_contributors counts multiple commits per author correctly."""

--- a/test_contributors.py
+++ b/test_contributors.py
@@ -229,6 +229,38 @@ class TestContributors(unittest.TestCase):
 
         self.assertEqual(result, [])
 
+    def test_get_contributors_skips_dict_author(self):
+        """Skip commits where github3.py left author as a raw dict instead of a ShortUser."""
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_commit = MagicMock()
+        mock_commit.author = {"name": "Detached Author", "email": "x@example.com"}
+        mock_repo.commits.return_value = iter([mock_commit])
+
+        with patch("builtins.print") as mock_print:
+            result = contributors_module.get_contributors(
+                mock_repo, "2022-01-01", "2022-12-31", ""
+            )
+
+        self.assertEqual(result, [])
+        mock_print.assert_not_called()
+
+    def test_get_contributors_no_commit_end_date_skips_user_without_login(self):
+        """Skip users from repo.contributors() that lack a usable login attribute."""
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        bad_user = {"name": "anon"}
+        good_user = MagicMock()
+        good_user.login = "real"
+        good_user.avatar_url = "https://avatars.githubusercontent.com/u/1"
+        good_user.contributions_count = 5
+        mock_repo.contributors.return_value = [bad_user, good_user]
+
+        result = contributors_module.get_contributors(mock_repo, "", "", "")
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].username, "real")
+
     def test_get_contributors_aggregates_multiple_commits(self):
         """Test get_contributors counts multiple commits per author correctly."""
         mock_repo = MagicMock()


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Closes #493 and addresses #492.

### What

Guard `get_sponsor_information` against a null `repositoryOwner` returned by the GraphQL `... on User` fragment, and guard `get_contributors` against `github3.py` leaving `commit.author` (or a `repo.contributors()` entry) as a raw dict instead of a `ShortUser`. Document the GitHub Discussions cross-repo token requirement in the README.

### Why

The monthly contributor report crashed with `'NoneType' object is not subscriptable` whenever a contributor login resolved to an Organization, a deleted/renamed user, or any non-User entity, because the `... on User` fragment returns null for non-User logins. Before that fatal error, `get_contributors` was already silently failing per-repo with `'dict' object has no attribute 'login'` whenever `github3.py` surfaced an author payload without a matching GitHub user. Both stop the workflow from producing the report.

The README addition addresses #492: `GITHUB_TOKEN` cannot create discussions in a *foreign* repository regardless of declared permissions, which is the actual root cause of `Resource not accessible by integration` errors on workflows that pipe `contributors.md` into `abirismyname/create-discussion` targeting another repo.

### Notes

- `avatars`/`counts` dicts are now typed explicitly; that's what unblocked `mypy` after switching to `getattr`-based attribute reads.
- `get_contributors` now falls through silently on dict/None authors rather than raising into the existing broad-`except`. That preserves partial output for the repository instead of returning `None` for the whole repo (current behavior loses every contributor on a single bad commit).
- README change is documentation-only; it does not alter the existing workflow examples (those create issues, not discussions).
- Follow-up out of scope here: the consumer workflow in `jmeridth/github-ospo` still needs its `create-discussion` step switched from `GITHUB_TOKEN` to a PAT or App token to fully resolve #492.

### Testing

- `make test` — 70 tests pass (3 new), 100% coverage maintained.
- New regression tests:
  - `test_fetch_sponsor_info_skips_when_repository_owner_is_none` — proves the #493 crash no longer happens for Org/deleted-user logins.
  - `test_get_contributors_skips_dict_author` — proves a commit whose `author` is a raw dict is skipped instead of crashing the whole repo.
  - `test_get_contributors_no_commit_end_date_skips_user_without_login` — proves the same guard on the `repo.contributors()` code path.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing