### PR TITLE
test: achieve 100% test coverage and require it in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	uv run python -m pytest -v --cov=. --cov-config=.coveragerc --cov-fail-under=80 --cov-report term-missing
+	uv run python -m pytest -v --cov=. --cov-config=.coveragerc --cov-fail-under=100 --cov-report term-missing
 
 .PHONY: clean
 clean:

--- a/test_contributors.py
+++ b/test_contributors.py
@@ -203,6 +203,24 @@ class TestContributors(unittest.TestCase):
             "",
         )
 
+    @patch("contributors.contributor_stats.ContributorStats")
+    def test_get_contributors_no_end_date_skips_bot(self, mock_contributor_stats):
+        """Test get_contributors skips bot users when using the repo.contributors() path."""
+        mock_repo = MagicMock()
+        mock_bot = MagicMock()
+        mock_bot.login = "dependabot[bot]"
+        mock_bot.avatar_url = "https://avatars.githubusercontent.com/u/0?v=4"
+        mock_bot.contributions_count = 50
+
+        mock_repo.contributors.return_value = [mock_bot]
+        mock_repo.full_name = "owner/repo"
+        ghe = ""
+
+        result = contributors_module.get_contributors(mock_repo, "2022-01-01", "", ghe)
+
+        self.assertEqual(result, [])
+        mock_contributor_stats.assert_not_called()
+
     def test_get_contributors_skips_when_no_commits_in_range(self):
         """Test get_contributors returns empty list when no commits in the date range."""
         mock_repo = MagicMock()


### PR DESCRIPTION
## Proposed Changes

The bot-skip branch in the `repo.contributors()` path (line 193 of `contributors.py`) was the only uncovered line, keeping coverage at 99.69%. I added a test that exercises this path with a `[bot]` user and raised the Makefile coverage threshold from 80% to 100% so regressions are caught immediately.

| Metric | Before | After |
|--------|--------|-------|
| Total coverage | 99.69% | 100% |
| Uncovered lines | 1 | 0 |
| `--cov-fail-under` | 80 | 100 |
| Test count | 64 passed | 65 passed |

**Tradeoffs:** Requiring 100% means future contributors must cover new lines before merging. Given the repo's small surface area (322 statements), this is a reasonable gate that prevents coverage drift without being burdensome.

## Testing

I ran `make test` and confirmed all 65 tests pass with 100% coverage. I ran `make lint` and confirmed a clean 10.00/10 pylint score with no issues from flake8, isort, mypy, or black.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
